### PR TITLE
Fix bad DEVICE_TOKEN issue

### DIFF
--- a/vinepy/api.py
+++ b/vinepy/api.py
@@ -9,14 +9,14 @@ from functools import partial
 from json import dumps
 
 class API(object):
-    def __init__(self, username=None, password=None, DEBUG=False):
+    def __init__(self, username=None, password=None, DEBUG=False, device_token=DEVICE_TOKEN):
         self.username = username
         self.password = password
         self._session_id = None
         self.DEBUG = DEBUG
 
         self._make_dynamic_methods()
-        self.user = self.login(username=username, password=password) if self.username and self.password else None
+        self.user = self.login(username=username, password=password, device_token=device_token) if self.username and self.password else None
 
 
     def _make_dynamic_methods(self):
@@ -129,7 +129,7 @@ class API(object):
             response = requests.request(meta['request_type'], url, params=built_params, data=built_data, headers=headers, verify=cafile, proxies=proxies)
             print 'REQUESTED: %s [%s]' % (url, response.status_code)
         else:
-            response = requests.request(meta['request_type'], url, params=built_params, data=built_data, headers=headers)
+            response = requests.request(meta['request_type'], url, params=built_params, data=built_data, headers=headers, verify=False)
 
         if response.headers.get('X-Upload-Key'):
             return response.headers['X-Upload-Key']

--- a/vinepy/endpoints.py
+++ b/vinepy/endpoints.py
@@ -2,26 +2,19 @@ from models import *
 
 PROTOCOL = 'https'
 API_HOST = 'api.vineapp.com'
-# API_HOST = 'api-dev.vineapp.com'
 MEDIA_HOST = 'media.vineapp.com'
-# MEDIA_HOST = 'media-dev.vineapp.com'
 
 HEADERS = {
-    'Host':              'api.vineapp.com',
-    'Proxy-Connection':  'keep-alive',
-    'Accept':            '*/*',
-    'X-Vine-Client':     'ios/2.5.1',
-    'Accept-Encoding':   'gzip, deflate',
-    'Content-Type':      'application/x-www-form-urlencoded; charset=utf-8',
-    'Accept-Language':   'en;q=1',
-    'Connection':        'keep-alive',
-    'User-Agent':        'iphone/172 (iPad; iOS 7.0.4; Scale/2.00)'
+    'User-Agent':      'iphone/1.3.1 (iPhone; iOS 6.1.4; Scale/2.00)',
+    'Accept-Language': 'en;q=1, fr;q=0.9, de;q=0.8, ja;q=0.7, nl;q=0.6, it;q=0.5',
+    'X-Vine-Client':   'ios/1.3.1',
+    'Accept-Encoding': 'gzip, deflate',
+    'Connection':      'keep-alive'
 }
-
 
 OPTIONAL_PARAMS = ['size', 'page', 'anchor']
 
-DEVICE_TOKEN = 'a3352a79c3e29053a03a2e6eb89587648f5b2a291c709708816ec768d058ea45'
+DEVICE_TOKEN = None
 
 ENDPOINTS = {
 
@@ -75,7 +68,7 @@ ENDPOINTS = {
         'request_type': 'put',
         'url_params': ['user_id'],
         'required_params': [],
-        'optional_params': ['username', 'description', 'location', 'locale', 'email', 'private', 'phoneNumber', 'avatarUrl', 'profileBackground', 'acceptsOutOfNetworkConversations'],
+        'optional_params': ['username', 'description', 'location', 'locale', 'email', 'private', 'phoneNumber', 'avatarUrl'],
         'model': None
     },
     'set_explicit': {

--- a/vinepy/models.py
+++ b/vinepy/models.py
@@ -89,12 +89,12 @@ class Model(AttrDict):
 
     def __repr__(self):
         classname = self.__class__.__name__
-        name = self.get('name', '')
-        if type(name) is int:
-            name = str(name)
+
+        if type(self.name) is int:
+            name = str(self.name)
         else:
             # description, usernames and comments may contain weird chars
-            name = name.encode(stdout.encoding)
+            name = self.name.encode(stdout.encoding)
             max_chars = 10
             name = name[:max_chars] + (name[max_chars:] and '...')
 
@@ -197,14 +197,12 @@ class User(Model):
             self.api.authenticate(self)
 
     @chained
-    def follow(self, user=None, **kwargs):
-        user = user or self
-        return self.api.follow(user_id=user.id, **kwargs)
+    def follow(self, **kwargs):
+        return self.api.follow(user_id=self.id, **kwargs)
 
     @chained
-    def unfollow(self, user=None, **kwargs):
-        user = user or self
-        return self.api.unfollow(user_id=user.id, **kwargs)
+    def unfollow(self, **kwargs):
+        return self.api.unfollow(user_id=self.id, **kwargs)
 
     @chained
     def block(self, **kwargs):


### PR DESCRIPTION
This fixes a problem due to a hard-coded device token in endpoints.py.  Vine is returning 502s if this value is set.  I changed the default to None, and provided an optional device_token keyword param in .login if the user wishes to set this explicitly.  

It works.
